### PR TITLE
Add Babele translation module support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.0
+
+- New Feature:
+  - Now module is compatible with [**Babele**](https://foundryvtt.com/packages/babele) translation module
+  - Allow searching by real and translated names
+
 # 1.1.1
 
 - Fixed Journals not being searchable when **Search world documents** is enabled

--- a/compendium-search.js
+++ b/compendium-search.js
@@ -88,7 +88,11 @@ class Search {
 
   static _hitTest(i, documentName, title, term, hits) {
     let name = i.name?.toLowerCase();
-    if (term.every((t) => name?.includes(t))) {
+
+    // If babele translation enabled and has original name
+    let originalName = i.flags?.babele?.originalName?.toLowerCase();
+
+    if (term.every((t) => name?.includes(t)) || term.every((t) => originalName?.includes(t))) {
       let typeLabel = documentName;
       if (documentName === 'Item' || documentName === 'Actor') {
         typeLabel = game.i18n.localize(CONFIG[documentName].typeLabels[i.type] ?? CONFIG[documentName].typeLabels.base);
@@ -96,6 +100,7 @@ class Search {
 
       hits.push({
         name: i.name,
+        originalName: i.originalName,
         details: typeLabel + ' - ' + title,
         thumbnail: i.img ?? i.thumb ?? getDocumentClass(documentName).DEFAULT_ICON ?? BACKUP_ICONS[documentName],
         uuid: i.uuid,

--- a/module.json
+++ b/module.json
@@ -2,9 +2,9 @@
   "id": "aedifs-compendium-search",
   "title": "Aedif's Compendium Search",
   "description": "Search compendiums and their contents.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "manifest": "https://github.com/Aedif/compendium-search/releases/latest/download/module.json",
-  "download": "https://github.com/Aedif/compendium-search/releases/download/1.1.1/aedifs-compendium-search.zip",
+  "download": "https://github.com/Aedif/compendium-search/releases/download/1.2.0/aedifs-compendium-search.zip",
   "compatibility": {
     "minimum": 11,
     "verified": 12

--- a/styles/compendium-search.css
+++ b/styles/compendium-search.css
@@ -32,6 +32,12 @@
     font-size: smaller;
 }
 
+.document-hits .hit .original-name {
+    line-height: normal;
+    color: gray;
+    font-size: x-small;
+}
+
 .document-hits .hit .description {
     display: flex;
     flex-direction: column;

--- a/templates/document-partial.html
+++ b/templates/document-partial.html
@@ -2,6 +2,7 @@
     <img class="thumbnail" title="{{name}}" src="{{thumbnail}}"/>
     <div class="description">
         <a class="name">{{name}}</a>
+        {{#if originalName}}<span class="original-name">{{originalName}}{{/if}}</span>
         <span class="details">{{details}}</span>
     </div>
 </li>


### PR DESCRIPTION
- Add support of translation, now module can search by **Original Name** and by **Translated** name which provided by [**Babele**](https://foundryvtt.com/packages/babele) module.
- Also if translation available showing **real name** near the **Translated**.
![image](https://github.com/user-attachments/assets/f1bac9ab-2358-4a5a-be91-2c8800074bab)
